### PR TITLE
Remove public prefix + disable "member-access" tslint rule

### DIFF
--- a/base/base_inner.ts
+++ b/base/base_inner.ts
@@ -1,17 +1,17 @@
   class EventEmitter {
-    public addListener(event: string, listener: Function): this;
-    public on(event: string, listener: Function): this;
-    public once(event: string, listener: Function): this;
-    public removeListener(event: string, listener: Function): this;
-    public removeAllListeners(event?: string): this;
-    public setMaxListeners(n: number): this;
-    public getMaxListeners(): number;
-    public listeners(event: string): Function[];
-    public emit(event: string, ...args: any[]): boolean;
-    public listenerCount(type: string): number;
-    public prependListener(event: string, listener: Function): this;
-    public prependOnceListener(event: string, listener: Function): this;
-    public eventNames(): string[];
+    addListener(event: string, listener: Function): this;
+    on(event: string, listener: Function): this;
+    once(event: string, listener: Function): this;
+    removeListener(event: string, listener: Function): this;
+    removeAllListeners(event?: string): this;
+    setMaxListeners(n: number): this;
+    getMaxListeners(): number;
+    listeners(event: string): Function[];
+    emit(event: string, ...args: any[]): boolean;
+    listenerCount(type: string): number;
+    prependListener(event: string, listener: Function): this;
+    prependOnceListener(event: string, listener: Function): this;
+    eventNames(): string[];
   }
 
   class Accelerator extends String {

--- a/lib/module-declaration.js
+++ b/lib/module-declaration.js
@@ -72,7 +72,7 @@ const generateModuleDeclaration = (module, index, API) => {
     }
 
     for (let method of ['on', 'once', 'addListener', 'removeListener']) {
-      moduleAPI.push(`${isClass ? 'public ' : ''}${method}(event: '${moduleEvent.name}', listener: ${listener}): this;`)
+      moduleAPI.push(`${method}(event: '${moduleEvent.name}', listener: ${listener}): this;`)
     }
   })
 
@@ -102,7 +102,7 @@ const generateModuleDeclaration = (module, index, API) => {
       }
 
       for (let method of ['addEventListener', 'removeEventListener']) {
-        moduleAPI.push(`${isClass ? 'public ' : ''}${method}(event: '${domEvent.name}', listener: (event: ${eventType}) => void${method === 'addEventListener' ? ', useCapture?: boolean' : ''}): this;`)
+        moduleAPI.push(`${method}(event: '${domEvent.name}', listener: (event: ${eventType}) => void${method === 'addEventListener' ? ', useCapture?: boolean' : ''}): this;`)
       }
     })
   }
@@ -113,8 +113,6 @@ const generateModuleDeclaration = (module, index, API) => {
     if (typeof prefix === 'undefined') {
       prefix = ''
     }
-    const markAsPublic = isClass ? 'public ' : ''
-    prefix = `${markAsPublic}${prefix}` || markAsPublic
     utils.extendArray(moduleAPI, utils.wrapComment(moduleMethod.description))
     let returnType = returnsThis(moduleMethod) ? 'this' : 'void'
 
@@ -167,7 +165,7 @@ const generateModuleDeclaration = (module, index, API) => {
     module.instanceProperties
       .sort((a, b) => a.name.localeCompare(b.name))
       .forEach(prop => {
-        moduleAPI.push(`public ${prop.name}: ${utils.typify(prop)};`)
+        moduleAPI.push(`${prop.name}: ${utils.typify(prop)};`)
       })
   }
 
@@ -177,10 +175,10 @@ const generateModuleDeclaration = (module, index, API) => {
       .sort((a, b) => a.name.localeCompare(b.name))
       .forEach(prop => {
         if (prop.type === 'Class') {
-          moduleAPI.push(`public static ${prop.name}: typeof ${prop.name};`)
+          moduleAPI.push(`static ${prop.name}: typeof ${prop.name};`)
           generateModuleDeclaration(prop, -1, API)
         } else {
-          moduleAPI.push(`public static ${prop.name}: ${utils.typify(prop)};`)
+          moduleAPI.push(`static ${prop.name}: ${utils.typify(prop)};`)
         }
       })
   }
@@ -196,14 +194,13 @@ const generateModuleDeclaration = (module, index, API) => {
           paramType = paramInterfaces.createParamInterface(p, '')
         }
 
-        const isPublic = isClass ? 'public ' : ''
         const isStatic = isStaticVersion ? 'static ' : ''
         const isOptional = utils.isOptional(p) ? '?' : ''
         const type = utils.typify(paramType)
 
         utils.extendArray(moduleAPI, utils.wrapComment(p.description))
         if (module.name === 'process' && p.name === 'versions') return
-        moduleAPI.push(`${isPublic}${isStatic}${p.name}${isOptional}: ${type};`)
+        moduleAPI.push(`${isStatic}${p.name}${isOptional}: ${type};`)
       })
   }
 

--- a/tslint.json
+++ b/tslint.json
@@ -1,17 +1,17 @@
 {
   "extends": "tslint:latest",
   "rules": {
-    "ban-types": false,
-    "max-line-length": [0],
-    "unified-signatures": false,
-    "interface-name": [false],
-    "max-classes-per-file": [false],
-    "member-ordering": [false],
-    "no-namespace": false,
-    "variable-name": false,
-    "no-empty-interface": false,
     "adjacent-overload-signatures": false,
-    "quotemark": [false],
-    "callable-types": [false]
+    "ban-types": false,
+    "callable-types": false,
+    "interface-name": false,
+    "max-classes-per-file": false,
+    "max-line-length": false,
+    "member-ordering": false,
+    "no-empty-interface": false,
+    "no-namespace": false,
+    "quotemark": false,
+    "unified-signatures": false,
+    "variable-name": false
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -7,6 +7,7 @@
     "interface-name": false,
     "max-classes-per-file": false,
     "max-line-length": false,
+    "member-access": false,
     "member-ordering": false,
     "no-empty-interface": false,
     "no-namespace": false,


### PR DESCRIPTION
The public prefix is not necessary and almost no definitions on DefinitelyTyped use them.