### PR TITLE
do not npmignore tests

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
-test
 electron-api-docs
 yarn.lock


### PR DESCRIPTION
Followup to #41 (v1.2.1) which adds some `tsc` checks that work in development but are not working in the published npm package.

I think the reason for this is that the `/test-smoke/electron/test` directory is being npmignored by the pattern `test`.