### PR TITLE
Change default optional value for methods and events

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -38,7 +38,7 @@ if (inFile) {
 
 const typeCheck = () => {
   const tscExec = path.resolve(require.resolve('typescript'), '../../bin/tsc')
-  const tscChild = childProcess.spawn(tscExec, ['--project', 'tsconfig.json'], {
+  const tscChild = childProcess.spawn('node', [tscExec, '--project', 'tsconfig.json'], {
     cwd: path.resolve(__dirname, 'test-smoke/electron')
   })
   tscChild.stdout.on('data', d => console.log(d.toString()))

--- a/lib/module-declaration.js
+++ b/lib/module-declaration.js
@@ -66,7 +66,7 @@ const generateModuleDeclaration = (module, index, API) => {
           newType = utils.genMethodString(paramInterfaces, module, eventListenerArg, eventListenerArg.parameters, null, true)
         }
 
-        args.push(`${argString}${utils.paramify(eventListenerArg.name)}${utils.isOptional(eventListenerArg) ? '?' : ''}: ${newType}`)
+        args.push(`${argString}${utils.paramify(eventListenerArg.name)}${utils.isOptional(eventListenerArg, false) ? '?' : ''}: ${newType}`)
       })
       listener = `(${args.join(`,\n${indent}`)}) => void`
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -116,19 +116,22 @@ const isEmitter = (module) => {
       return true
   }
 }
-const isOptional = (param) => {
+const isOptional = (param, defaultReturn) => {
+  if (typeof defaultReturn === 'undefined') {
+    defaultReturn = true
+  }
   // Does the description contain the word "optional"?
   if (/optional/i.test(param.description)) {
     return true
   }
 
   // Did we pass a "required"?
-  if (param.required) {
+  if (typeof param.required !== 'undefined') {
     return !param.required
   }
 
   // Does the description not contain the word "required"?
-  if (param.description && !/required/i.test(param.description)) {
+  if (param.description && !/required/i.test(param.description) && /\(.+\)/.test(param.description)) {
     return true
   }
 
@@ -136,7 +139,7 @@ const isOptional = (param) => {
   // ruins the developer experience, why a false negative is only
   // slightly annoying
   debug(`Could not determine optionality for ${param.name}`)
-  return true
+  return defaultReturn
 }
 
 const genMethodString = (paramInterfaces, module, moduleMethod, parameters, returns, includeType, paramTypePrefix) => {
@@ -166,7 +169,7 @@ const genMethodString = (paramInterfaces, module, moduleMethod, parameters, retu
     }
 
     const name = paramify(param.name)
-    const optional = isOptional(param) ? '?' : ''
+    const optional = isOptional(param, false) ? '?' : ''
 
     // Figure out this parameter's type
     let type


### PR DESCRIPTION
Fixes #48 

/cc @felixrieseberg You made the original change before to default this to true for everything, it appears to was purely to fix all the constructor object properties needing to be optional by default so I think this still covers that case