### PR TITLE
support returning custom types

### DIFF
--- a/lib/module-declaration.js
+++ b/lib/module-declaration.js
@@ -117,7 +117,12 @@ const generateModuleDeclaration = (module, index, API) => {
     let returnType = returnsThis(moduleMethod) ? 'this' : 'void'
 
     if (moduleMethod.returns) {
-      returnType = moduleMethod.returns
+      // Account for methods on the process module that return a custom type/structure
+      if (module.name === 'process' && moduleMethod.returns.type !== 'Object') {
+        returnType = `Electron.${moduleMethod.returns.type}`
+      } else {
+        returnType = moduleMethod.returns
+      }
     }
 
     if (returnType === 'Object' || returnType.type === 'Object') {

--- a/lib/module-declaration.js
+++ b/lib/module-declaration.js
@@ -117,11 +117,10 @@ const generateModuleDeclaration = (module, index, API) => {
     let returnType = returnsThis(moduleMethod) ? 'this' : 'void'
 
     if (moduleMethod.returns) {
-      // Account for methods on the process module that return a custom type/structure
+      returnType = moduleMethod.returns
+      // Account for methods on the process module that return a custom type/structure, we need to reference the Electron namespace to use these types
       if (module.name === 'process' && moduleMethod.returns.type !== 'Object') {
         returnType = `Electron.${moduleMethod.returns.type}`
-      } else {
-        returnType = moduleMethod.returns
       }
     }
 

--- a/vendor/fetch-docs.js
+++ b/vendor/fetch-docs.js
@@ -7,7 +7,7 @@ const mkdirp = require('mkdirp').sync
 const os = require('os')
 
 const downloadPath = path.join(os.tmpdir(), 'electron-api-tmp')
-const ELECTRON_COMMIT = 'a6e11d3b63cb7ca3b3661b6a56a853358b1ab734'
+const ELECTRON_COMMIT = '116403ed03997d7252f2874a781a6b61600795b2'
 
 rm(downloadPath)
 


### PR DESCRIPTION
The `process` module is a special case because it's part of the NodeJS namespace. As such, the `Electron.` prefix must be used to refer to anything outside the NodeJS process namespace.

This PR updates that special case scenario to account for `process` methods that return custom types, such as `CPUUsage` and `IOCounters`.

Fixes https://github.com/electron/electron/pull/9599