### PR TITLE
Wrap numeric keys in quotes

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -74,6 +74,12 @@ apiPromise.then(API => {
       console.log('\n\n----------\n\n')
       console.log(failure)
     })
+
+    // Save file for debugging purpsoses
+    const debugFile = path.resolve(__dirname, 'test-smoke/electron/index.d.ts')
+    fs.writeFileSync(debugFile, output)
+    console.log(`See ${debugFile}`)
+
     process.exit(1)
   }
 })

--- a/cli.js
+++ b/cli.js
@@ -68,7 +68,12 @@ apiPromise.then(API => {
     typeCheck()
   } else {
     console.error('Failed to lint electron.d.ts')
-    console.error(result)
+    result.failures.forEach(failure => {
+      delete failure.rawLines
+      delete failure.sourceFile
+      console.log('\n\n----------\n\n')
+      console.log(failure)
+    })
     process.exit(1)
   }
 })

--- a/lib/module-declaration.js
+++ b/lib/module-declaration.js
@@ -204,7 +204,13 @@ const generateModuleDeclaration = (module, index, API) => {
 
         utils.extendArray(moduleAPI, utils.wrapComment(p.description))
         if (module.name === 'process' && p.name === 'versions') return
-        moduleAPI.push(`${isStatic}${p.name}${isOptional}: ${type};`)
+
+        if (p.name.match(/^\d/)) {
+          // Wrap key in quotes if it starts with a number, e.g. `2d_canvas`
+          moduleAPI.push(`'${isStatic}${p.name}${isOptional}': ${type};`)
+        } else {
+          moduleAPI.push(`${isStatic}${p.name}${isOptional}: ${type};`)
+        }
       })
   }
 

--- a/vendor/fetch-docs.js
+++ b/vendor/fetch-docs.js
@@ -7,7 +7,7 @@ const mkdirp = require('mkdirp').sync
 const os = require('os')
 
 const downloadPath = path.join(os.tmpdir(), 'electron-api-tmp')
-const ELECTRON_COMMIT = '116403ed03997d7252f2874a781a6b61600795b2'
+const ELECTRON_COMMIT = '02972fac86ffd2d87c5513840b0f303886257e07'
 
 rm(downloadPath)
 


### PR DESCRIPTION
Fixes #60 

This PR wraps key names like `2d_canvs` in quotes to prevent TS compiler errors. It also updates the CLI to produce more readable error output.