### PR TITLE
Event definition is wrong (fixes #73)

### DIFF
--- a/base/base_inner.ts
+++ b/base/base_inner.ts
@@ -22,7 +22,8 @@
     preventDefault: () => void;
     sender: WebContents;
     returnValue: any;
-    ctrlkey?: boolean;
+    ctrlKey?: boolean;
     metaKey?: boolean;
     shiftKey?: boolean;
+    altKey?: boolean;
   }


### PR DESCRIPTION
According to: https://github.com/electron/electron/blob/787bc8570382e98c4f204abff05b2af122e5a422/atom/browser/api/event_emitter.cc#L71

Helps for https://github.com/electron/electron/issues/10448