### PR TITLE
Add add/removeEventListener overloads from HTMLElement

### DIFF
--- a/lib/module-declaration.js
+++ b/lib/module-declaration.js
@@ -105,6 +105,12 @@ const generateModuleDeclaration = (module, index, API) => {
         moduleAPI.push(`${method}(event: '${domEvent.name}', listener: (event: ${eventType}) => void${method === 'addEventListener' ? ', useCapture?: boolean' : ''}): this;`)
       }
     })
+
+    // original overloads copied from HTMLElement, because they are not inherited
+    moduleAPI.push(`addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, useCapture?: boolean): void;`)
+    moduleAPI.push(`addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;`)
+    moduleAPI.push(`removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, useCapture?: boolean): void;`)
+    moduleAPI.push(`removeEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;`)
   }
 
   const returnsThis = (moduleMethod) => ['on', 'once', 'removeAllListeners', 'removeListener'].includes(moduleMethod.name)


### PR DESCRIPTION
WebviewTag adds electron-specific overloads to addEventListener and removeEventListener when it extends HTMLElement. However, it does not include the original overloads from HTMLElement, and Typescript does not include them when WebviewTag extends HTMLElement. This change adds those previously-missed overloads to WebviewTag. It is necessary to allow users of electron.d.ts to compile with Typescript 2.6 --strict.

Fixes #79