### PR TITLE
Better detect dupplicate declarations of the same interface

### DIFF
--- a/lib/dynamic-param-interfaces.js
+++ b/lib/dynamic-param-interfaces.js
@@ -73,7 +73,13 @@ const flushParamInterfaces = (API, addToOutput) => {
         return
       }
       if (declared[paramKey]) {
-        if (!_.isEqual(paramInterfacesToDeclare[paramKey], declared[paramKey])) {
+        const toDeclareCheck = Object.assign({}, paramInterfacesToDeclare[paramKey])
+        const declaredCheck = Object.assign({}, declared[paramKey])
+        for (const prop of ['type', 'collection', 'required', 'description']) {
+          delete toDeclareCheck[prop]
+          delete declaredCheck[prop]
+        }
+        if (!_.isEqual(toDeclareCheck, declaredCheck)) {
           throw new Error('Ruh roh, "' + paramKey + '" is already declared')
         }
         delete paramInterfacesToDeclare[paramKey]

--- a/vendor/fetch-docs.js
+++ b/vendor/fetch-docs.js
@@ -7,7 +7,7 @@ const mkdirp = require('mkdirp').sync
 const os = require('os')
 
 const downloadPath = path.join(os.tmpdir(), 'electron-api-tmp')
-const ELECTRON_COMMIT = 'cb3c5ded0f99a15edc99b61d227d135f7c3521c8'
+const ELECTRON_COMMIT = 'f469059e9059aa0bda756022deb53322688dac29'
 
 rm(downloadPath)
 


### PR DESCRIPTION
* Ignore required
* Ignore collection
* Ignore description

Only properties / parameters should determine if the interface is the same

Fixes current electron master 👍 