### PR TITLE
Add support for abstract TouchBarItem

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -97,6 +97,8 @@ const typify = (type) => {
       return 'Promise<any>'
     case 'url':
       return 'string'
+    case 'touchbaritem':
+      return '(TouchBarButton | TouchBarColorPicker | TouchBarGroup | TouchBarLabel | TouchBarPopover | TouchBarScrubber | TouchBarSegmentedControl | TouchBarSlider | TouchBarSpacer | null)'
   }
   // if (type.substr(0, 8) === 'TouchBar' && type !== 'TouchBar') {
   //   return `Electron.${type}`


### PR DESCRIPTION
This just adds a helper to make it easier to add `TouchBarItem` as a type in the TB docs