### PR TITLE
fix: avoid leaking secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 test-smoke/electron/index.d.ts
 test-smoke/**/*.js
 yarn.lock
+.npmrc
+.env

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
 electron-api-docs
 yarn.lock
+.npmrc
+.env


### PR DESCRIPTION
semantic-release noticed that we were not gitignoring `.npmrc`:

```
> electron-typescript-definitions@1.3.0 prepack .
> check-for-leaks
warning: .npmrc is not in your .gitignore file
warning: .npmrc is not in your .npmignore file
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! electron-typescript-definitions@1.3.0 prepack: `check-for-leaks`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the electron-typescript-definitions@1.3.0 prepack script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/travis/.npm/_logs/2018-02-12T19_15_06_376Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! electron-typescript-definitions@0.0.0-development semantic-release: `semantic-release pre && npm publish && semantic-release
```