### PR TITLE
fix: Special case ReadableStream type to mean Node.js ReadableStream

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -92,13 +92,19 @@ const typify = (type) => {
     case 'buffer':
       return 'Buffer'
     case 'buffer[]':
-      return 'Buffer[]'
+      return 'Buffer[']
     case 'promise':
       return 'Promise<any>'
     case 'url':
       return 'string'
     case 'touchbaritem':
       return '(TouchBarButton | TouchBarColorPicker | TouchBarGroup | TouchBarLabel | TouchBarPopover | TouchBarScrubber | TouchBarSegmentedControl | TouchBarSlider | TouchBarSpacer | null)'
+    case 'readablestream':
+      // See StreamProtocolResponse.data which accepts a Node.js readable stream.
+      // The ReadableStream type unfortunately conflicts with the ReadableStream interface
+      // defined in the Streams standard (https://streams.spec.whatwg.org/#rs-class) so
+      // we'll have to qualify it with the Node.js namespace.
+      return 'NodeJS.ReadableStream'
   }
   // if (type.substr(0, 8) === 'TouchBar' && type !== 'TouchBar') {
   //   return `Electron.${type}`

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -92,7 +92,7 @@ const typify = (type) => {
     case 'buffer':
       return 'Buffer'
     case 'buffer[]':
-      return 'Buffer[']
+      return 'Buffer[]'
     case 'promise':
       return 'Promise<any>'
     case 'url':


### PR DESCRIPTION
The [StreamProtocolResponse.data](https://github.com/electron/electron/blob/master/docs/api/structures/stream-protocol-response.md) property is supposed to be a **Node.js** readable stream.

Unfortunately the `ReadableStream` type is ambiguous between the Node.js `ReadableStream` and the `ReadableStream` interface defined in the [web Streams standard](https://streams.spec.whatwg.org/#rs-class) and since the web stream standard is part of the standard lib in TS it'll choose that.

This PR special cases the `ReadableStream` type name to qualify it with the Node.js namespace.

I wasn't sure what the best approach here would be, special case it in the definition generator or update the documentation to be explicit about the type.

I'm happy to drop this and PR a change to the docs if you'd like.

Diff of generated definitions before/after this change

```diff
--- electron.d.ts       2018-05-09 14:42:49.000000000 +0200
+++ electron-niik.d.ts  2018-05-09 14:48:05.000000000 +0200
@@ -3468,7 +3468,7 @@
      * Same as protocol.registerStreamProtocol, except that it replaces an existing
      * protocol handler.
      */
-    interceptStreamProtocol(scheme: string, handler: (request: InterceptStreamProtocolRequest, callback: (stream?: ReadableStream | StreamProtocolResponse) => void) => void, completion?: (error: Error) => void): void;
+    interceptStreamProtocol(scheme: string, handler: (request: InterceptStreamProtocolRequest, callback: (stream?: NodeJS.ReadableStream | StreamProtocolResponse) => void) => void, completion?: (error: Error) => void): void;
     /**
      * Intercepts scheme protocol and uses handler as the protocol's new handler which
      * sends a String as a response.
@@ -3537,7 +3537,7 @@
      * that implements the readable stream API (emits data/end/error events). For
      * example, here's how a file could be returned:
      */
-    registerStreamProtocol(scheme: string, handler: (request: RegisterStreamProtocolRequest, callback: (stream?: ReadableStream | StreamProtocolResponse) => void) => void, completion?: (error: Error) => void): void;
+    registerStreamProtocol(scheme: string, handler: (request: RegisterStreamProtocolRequest, callback: (stream?: NodeJS.ReadableStream | StreamProtocolResponse) => void) => void, completion?: (error: Error) => void): void;
     /**
      * Registers a protocol of scheme that will send a String as a response. The usage
      * is the same with registerFileProtocol, except that the callback should be called
@@ -3951,7 +3951,7 @@
     /**
      * A Node.js readable stream representing the response body
      */
-    data: ReadableStream;
+    data: NodeJS.ReadableStream;
     /**
      * An object containing the response headers
      */
```

cc @zeke 