### PR TITLE
Move project URL to electronjs.org

### DIFF
--- a/base/base_header.ts
+++ b/base/base_header.ts
@@ -1,5 +1,5 @@
 // Type definitions for Electron <<VERSION>>
-// Project: http://electron.atom.io/
+// Project: http://electronjs.org/
 // Definitions by: The Electron Team <https://github.com/electron/electron>
 // Definitions: https://github.com/electron/electron-typescript-definitions
 


### PR DESCRIPTION
Change the project URL from atom.io to electronjs.org.

I noticed electron-api.json was full of entries like

```json
    "websiteUrl": "http://electron.atom.io/docs/api/browser-window",
```