### PR TITLE
fix: TypeScript definitions test failing due to use of obsolete makeSingleInstance method

### DIFF
--- a/test-smoke/electron/test/main.ts
+++ b/test-smoke/electron/test/main.ts
@@ -45,15 +45,9 @@ app.on("window-all-closed", () => {
 });
 
 // Check single instance app
-const shouldQuit = app.makeSingleInstance(function(commandLine, workingDirectory) {
-  // Someone tried to run a second instance, we should focus our window
-  if (mainWindow) {
-    if (mainWindow.isMinimized()) mainWindow.restore();
-    mainWindow.focus();
-  }
-});
+const primaryInstance = app.requestSingleInstanceLock();
 
-if (shouldQuit) {
+if (!primaryInstance) {
   app.quit();
   process.exit(0);
 }


### PR DESCRIPTION
See https://github.com/electron/electron/pull/12782, makeSingleInstance isn't a thing any more as of https://github.com/electron/electron/pull/12782