### PR TITLE
remove reference to webFrame.registerURLSchemeAsSecure

### DIFF
--- a/test-smoke/electron/test/renderer.ts
+++ b/test-smoke/electron/test/renderer.ts
@@ -66,7 +66,6 @@ webFrame.setSpellCheckProvider('en-US', true, {
 	}
 });
 
-webFrame.registerURLSchemeAsSecure('app');
 webFrame.registerURLSchemeAsBypassingCSP('app');
 webFrame.registerURLSchemeAsPrivileged('app');
 webFrame.registerURLSchemeAsPrivileged('app', {


### PR DESCRIPTION
In coordination with the imminent release of `3.0.0`, remove deprecated reference to `webFrame.registerURLSchemeAsSecure('app')`.

Fixes TS definitions error in https://github.com/electron/electron/pull/13050.

/cc @MarshallOfSound @electron/electrocats 