### PR TITLE
chore: Revert "fix: `position` is dead, long live `before/after`"

### DIFF
--- a/test-smoke/electron/test/main.ts
+++ b/test-smoke/electron/test/main.ts
@@ -739,19 +739,19 @@ Menu.setApplicationMenu(menu); // Must be called within app.on('ready', function
 
 Menu.buildFromTemplate([
   { label: "4", id: "4" },
-  { label: "5", id: "5", after: ["4"] },
-  { label: "1", id: "1", before: ["4"] },
-  { label: "2", id: "2",  },
+  { label: "5", id: "5" },
+  { label: "1", id: "1", position: "before=4" },
+  { label: "2", id: "2" },
   { label: "3", id: "3" },
 ]);
 
 Menu.buildFromTemplate([
-  { label: "a" },
-  { label: "1" },
-  { label: "b" },
-  { label: "2" },
-  { label: "c" },
-  { label: "3" },
+  { label: "a", position: "endof=letters" },
+  { label: "1", position: "endof=numbers" },
+  { label: "b", position: "endof=letters" },
+  { label: "2", position: "endof=numbers" },
+  { label: "c", position: "endof=letters" },
+  { label: "3", position: "endof=numbers" },
 ]);
 
 // net

--- a/vendor/fetch-docs.js
+++ b/vendor/fetch-docs.js
@@ -7,7 +7,7 @@ const mkdirp = require('mkdirp').sync
 const os = require('os')
 
 const downloadPath = path.join(os.tmpdir(), 'electron-api-tmp')
-const ELECTRON_COMMIT = '7a508ca587ecc1f66c51bbce14a5dae6b7147c3c'
+const ELECTRON_COMMIT = '7c7543cb39c5a65e3ec49dae1a09f48f963f27bf'
 
 rm(downloadPath)
 


### PR DESCRIPTION
Reverts electron/electron-typescript-definitions#108