### PR TITLE
fix: update zoom fns for sync

### DIFF
--- a/test-smoke/electron/test/main.ts
+++ b/test-smoke/electron/test/main.ts
@@ -685,9 +685,8 @@ const template = <Electron.MenuItemConstructorOptions[]> [
         click: (item, focusedWindow) => {
           if (focusedWindow) {
             const { webContents } = focusedWindow;
-            webContents.getZoomLevel((zoomLevel) => {
-              webContents.setZoomLevel(zoomLevel + 0.5);
-            });
+            const zoomLevel = webContents.getZoomLevel();
+            webContents.setZoomLevel(zoomLevel + 0.5);
           }
         },
       },
@@ -697,9 +696,8 @@ const template = <Electron.MenuItemConstructorOptions[]> [
         click: (item, focusedWindow) => {
           if (focusedWindow) {
             const { webContents } = focusedWindow;
-            webContents.getZoomLevel((zoomLevel) => {
-              webContents.setZoomLevel(zoomLevel - 0.5);
-            });
+            const zoomLevel = webContents.getZoomLevel();
+            webContents.setZoomLevel(zoomLevel - 0.5);
           }
         },
       },

--- a/vendor/fetch-docs.js
+++ b/vendor/fetch-docs.js
@@ -7,7 +7,7 @@ const mkdirp = require('mkdirp').sync
 const os = require('os')
 
 const downloadPath = path.join(os.tmpdir(), 'electron-api-tmp')
-const ELECTRON_COMMIT = '76dbbf51fe86995e2f206a1b9c144051d33c8215'
+const ELECTRON_COMMIT = '5454cd01125b9abcf89a6ec1f8622bbe2107ea81'
 
 rm(downloadPath)
 


### PR DESCRIPTION
Fixes lint failures in https://github.com/electron/electron/pull/16410.

Update zoom-related `MenuItems` to be synchronous.

cc @MarshallOfSound @ckerr @deepak1556 