### PR TITLE
chore: bump ELECTRON_COMMIT for cookie promises api

### DIFF
--- a/test-smoke/electron/test/main.ts
+++ b/test-smoke/electron/test/main.ts
@@ -1003,6 +1003,38 @@ shell.beep();
 
 shell.writeShortcutLink("/home/user/Desktop/shortcut.lnk", "update", shell.readShortcutLink("/home/user/Desktop/shortcut.lnk"));
 
+// cookies
+// https://github.com/atom/electron/blob/master/docs/api/cookies.md
+{
+  const { session } = require('electron')
+
+  // Query all cookies.
+  session.defaultSession.cookies.get({})
+    .then((cookies) => {
+      console.log(cookies)
+    }).catch((error) => {
+      console.log(error)
+    })
+
+  // Query all cookies associated with a specific url.
+  session.defaultSession.cookies.get({ url: 'http://www.github.com' })
+    .then((cookies) => {
+      console.log(cookies)
+    }).catch((error) => {
+      console.log(error)
+    })
+
+  // Set a cookie with the given cookie data;
+  // may overwrite equivalent cookies if they exist.
+  const cookie = { url: 'http://www.github.com', name: 'dummy_name', value: 'dummy' }
+  session.defaultSession.cookies.set(cookie)
+    .then(() => {
+      // success
+    }, (error) => {
+      console.error(error)
+    })
+}
+
 // session
 // https://github.com/atom/electron/blob/master/docs/api/session.md
 
@@ -1011,25 +1043,6 @@ session.defaultSession.on("will-download", (event, item, webContents) => {
   require("request")(item.getURL(), (data: any) => {
     require("fs").writeFileSync("/somewhere", data);
   });
-});
-
-// Query all cookies.
-session.defaultSession.cookies.get({}, (error, cookies) => {
-  console.log(cookies);
-});
-
-// Query all cookies associated with a specific url.
-session.defaultSession.cookies.get({ url: "http://www.github.com" }, (error, cookies) => {
-  console.log(cookies);
-});
-
-// Set a cookie with the given cookie data;
-// may overwrite equivalent cookies if they exist.
-const cookie = { url: "http://www.github.com", name: "dummy_name", value: "dummy" };
-session.defaultSession.cookies.set(cookie, (error) => {
-  if (error) {
-    console.error(error);
-  }
 });
 
 // In the main process.

--- a/vendor/fetch-docs.js
+++ b/vendor/fetch-docs.js
@@ -7,7 +7,7 @@ const mkdirp = require('mkdirp').sync
 const os = require('os')
 
 const downloadPath = path.join(os.tmpdir(), 'electron-api-tmp')
-const ELECTRON_COMMIT = '71b9c74d684c3fc03eb31e8a3de7cf9f797cfaf1'
+const ELECTRON_COMMIT = '0c96f14a5b702036559a8012ef0dd9649221d5d9'
 
 rm(downloadPath)
 

--- a/vendor/fetch-docs.js
+++ b/vendor/fetch-docs.js
@@ -7,7 +7,7 @@ const mkdirp = require('mkdirp').sync
 const os = require('os')
 
 const downloadPath = path.join(os.tmpdir(), 'electron-api-tmp')
-const ELECTRON_COMMIT = '5454cd01125b9abcf89a6ec1f8622bbe2107ea81'
+const ELECTRON_COMMIT = '71b9c74d684c3fc03eb31e8a3de7cf9f797cfaf1'
 
 rm(downloadPath)
 


### PR DESCRIPTION
Point e-t-d to https://github.com/electron/electron/pull/16464 to pick up the new promise versions of our Cookie CRUD API

CC @codebytere, @MarshallOfSound