### PR TITLE
fix: Update tests for new schemes api

### DIFF
--- a/test-smoke/electron/test/main.ts
+++ b/test-smoke/electron/test/main.ts
@@ -827,8 +827,7 @@ powerSaveBlocker.stop(id);
 // https://github.com/atom/electron/blob/master/docs/api/protocol.md
 
 app.on("ready", () => {
-  protocol.registerStandardSchemes(["https"]);
-  protocol.registerServiceWorkerSchemes(["https"]);
+  protocol.registerSchemesAsPrivileged([{ scheme: "https", privileges: { standard: true, allowServiceWorkers: true } }]);
 
   protocol.registerFileProtocol("atom", (request, callback) => {
     callback(`${__dirname}/${request.url}`);

--- a/test-smoke/electron/test/renderer.ts
+++ b/test-smoke/electron/test/renderer.ts
@@ -70,13 +70,6 @@ webFrame.setSpellCheckProvider('en-US', {
   }
 })
 
-webFrame.registerURLSchemeAsBypassingCSP('app');
-webFrame.registerURLSchemeAsPrivileged('app');
-webFrame.registerURLSchemeAsPrivileged('app', {
-	secure: true,
-	supportFetchAPI: true,
-});
-
 webFrame.insertText('text');
 
 webFrame.executeJavaScript('JSON.stringify({})', false, (result) => {

--- a/vendor/fetch-docs.js
+++ b/vendor/fetch-docs.js
@@ -7,7 +7,7 @@ const mkdirp = require('mkdirp').sync
 const os = require('os')
 
 const downloadPath = path.join(os.tmpdir(), 'electron-api-tmp')
-const ELECTRON_COMMIT = '0c96f14a5b702036559a8012ef0dd9649221d5d9'
+const ELECTRON_COMMIT = '1a93b81a10fa63fce2e404ae71c0289d373e08f4'
 
 rm(downloadPath)
 


### PR DESCRIPTION
This PR updates the tests to use the new schemes changes that have landed in electron.