### PR TITLE
fix: tests after webFrame API changes

### DIFF
--- a/test-smoke/electron/test/main.ts
+++ b/test-smoke/electron/test/main.ts
@@ -827,8 +827,14 @@ powerSaveBlocker.stop(id);
 // https://github.com/atom/electron/blob/master/docs/api/protocol.md
 
 app.on("ready", () => {
-  protocol.registerStandardSchemes(["https"]);
-  protocol.registerServiceWorkerSchemes(["https"]);
+  // protocol.registerSchemesAsPrivileged([
+  //   { scheme: 'app', options: { standard: true, secure: true } },
+  //   { scheme: 'zoom', options: { standard: true, secure: true } },
+  //   { scheme: 'cors', options: { corsEnabled: true, supportFetchAPI: true } },
+  //   { scheme: 'cors-blob', options: { corsEnabled: true, supportFetchAPI: true } },
+  //   { scheme: 'no-cors', options: { supportFetchAPI: true } },
+  //   { scheme: 'no-fetch', options: { corsEnabled: true } }
+  // ])
 
   protocol.registerFileProtocol("atom", (request, callback) => {
     callback(`${__dirname}/${request.url}`);

--- a/test-smoke/electron/test/renderer.ts
+++ b/test-smoke/electron/test/renderer.ts
@@ -70,13 +70,6 @@ webFrame.setSpellCheckProvider('en-US', {
   }
 })
 
-webFrame.registerURLSchemeAsBypassingCSP('app');
-webFrame.registerURLSchemeAsPrivileged('app');
-webFrame.registerURLSchemeAsPrivileged('app', {
-	secure: true,
-	supportFetchAPI: true,
-});
-
 webFrame.insertText('text');
 
 webFrame.executeJavaScript('JSON.stringify({})', false, (result) => {


### PR DESCRIPTION
https://github.com/electron/electron/pull/16416
```
test/main.ts(830,12): error TS2339: Property 'registerStandardSchemes' does not exist on type 'Protocol'.
test/main.ts(831,12): error TS2339: Property 'registerServiceWorkerSchemes' does not exist on type 'Protocol'.
test/renderer.ts(73,10): error TS2339: Property 'registerURLSchemeAsBypassingCSP' does not exist on type 'WebFrame'.
test/renderer.ts(74,10): error TS2339: Property 'registerURLSchemeAsPrivileged' does not exist on type 'WebFrame'.
test/renderer.ts(75,10): error TS2339: Property 'registerURLSchemeAsPrivileged' does not exist on type 'WebFrame'.
```