### PR TITLE
feat: add new known VoidFunction type

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -101,6 +101,8 @@ const typify = (type) => {
       return 'Buffer'
     case 'buffer[]':
       return 'Buffer[]'
+    case 'VoidFunction':
+      return '() => void'
     case 'promise':
       if (innerType) {
         return `Promise<${innerType}>`

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -101,8 +101,8 @@ const typify = (type) => {
       return 'Buffer'
     case 'buffer[]':
       return 'Buffer[]'
-    case 'VoidFunction':
-      return '() => void'
+    case 'voidfunction':
+      return '(() => void)'
     case 'promise':
       if (innerType) {
         return `Promise<${innerType}>`

--- a/test/utils_spec.js
+++ b/test/utils_spec.js
@@ -62,7 +62,7 @@ describe('utils', () => {
     })
 
     it('should correctly convert a void function', () => {
-      expect(utils.typify('VoidFunction')).to.equal('() => void')
+      expect(utils.typify('VoidFunction')).to.equal('(() => void)')
     })
 
     it('should lower case known array types', () => {

--- a/test/utils_spec.js
+++ b/test/utils_spec.js
@@ -61,6 +61,10 @@ describe('utils', () => {
       expect(utils.typify('Number')).to.equal('number')
     })
 
+    it('should correctly convert a void function', () => {
+      expect(utils.typify('VoidFunction')).to.equal('() => void')
+    })
+
     it('should lower case known array types', () => {
       expect(utils.typify('String[]')).to.equal('string[]')
       expect(utils.typify('Number[]')).to.equal('number[]')


### PR DESCRIPTION
Account for situations like inherited `GlobalEvent` which has a type `preventDefault` of type `() => void`

cc @MarshallOfSound 