### PR TITLE
fix: update eventNames API signature to match node

### DIFF
--- a/base/base_inner.ts
+++ b/base/base_inner.ts
@@ -1,3 +1,4 @@
+  // TODO: Replace this declaration with NodeJS.EventEmitter
   class EventEmitter {
     addListener(event: string, listener: Function): this;
     on(event: string, listener: Function): this;
@@ -11,7 +12,7 @@
     listenerCount(type: string): number;
     prependListener(event: string, listener: Function): this;
     prependOnceListener(event: string, listener: Function): this;
-    eventNames(): string[];
+    eventNames(): Array<(string | symbol)>;
   }
 
   class Accelerator extends String {


### PR DESCRIPTION
This will fix an issue with matching `EventEmitter` in Electron's code to this definition

cc @felixrieseberg @codebytere 