### PR TITLE
feat: add support for Record<A, B>

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -74,7 +74,7 @@ const typify = (type) => {
     case 'float[]':
       return 'number[]'
     case 'array': {
-      if (innerType) return `Array<${innerType}>`
+      if (innerType) return `Array<${typify(innerType[0])}>`
       debug('Untyped "Array" as return type'.yellow)
       return 'any[]'
     }
@@ -105,10 +105,16 @@ const typify = (type) => {
       return '(() => void)'
     case 'promise':
       if (innerType) {
-        return `Promise<${innerType}>`
+        return `Promise<${typify(innerType[0])}>`
       }
       debug('Promise with missing inner type, defaulting to any')
       return 'Promise<any>'
+    case 'record':
+      if (innerType && innerType.length === 2) {
+        return `Record<${typify(innerType[0])}, ${typify(innerType[1])}>`
+      }
+      debug('Record with missing inner types, default to any')
+      return 'Record<any, any>'
     case 'url':
       return 'string'
     case 'touchbaritem':
@@ -196,7 +202,7 @@ const genMethodString = (paramInterfaces, module, moduleMethod, parameters, retu
     if (Array.isArray(param.type)) {
       param.type = param.type.map((paramType) => {
         if (paramType.typeName === 'Function' && param.parameters) {
-          return Object.assign({}, paramType, { typeName: genMethodString(paramInterfaces, module, moduleMethod, param.parameters, param.returns || paramType.innerType) })
+          return Object.assign({}, paramType, { typeName: genMethodString(paramInterfaces, module, moduleMethod, param.parameters, param.returns || (paramType.innerType && paramType.innerType[0])) })
         }
         return paramType
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1664,9 +1664,9 @@
       }
     },
     "electron-docs-linter": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/electron-docs-linter/-/electron-docs-linter-2.5.0.tgz",
-      "integrity": "sha512-EgnfNA/dbRvUKpJQ+Wh6ncgGK/j0gh2udYEtOCr2noge/mNjlzhpENFBY3zUvDwFVnhgnhLUKRgbfWKwvoNnfA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/electron-docs-linter/-/electron-docs-linter-3.0.0.tgz",
+      "integrity": "sha512-XA+cVmPcpEDGsVn+eUZtee1Dp5JHWWT3Ll9f1rERTJUvT6wN63mJxRQII73sm3qIhBD5gCTXKk7vCf4MKr/0JQ==",
       "requires": {
         "cheerio": "^1.0.0-rc.2",
         "clean-deep": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "colors": "^1.1.2",
     "debug": "^2.6.3",
     "electron-docs": "^2.0.0",
-    "electron-docs-linter": "^2.5.0",
+    "electron-docs-linter": "^3.0.0",
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.5.4",


### PR DESCRIPTION
Blocked pending: https://github.com/electron/electron-docs-linter/pull/112

Add support for `Record<A, B>` in our documentation as types to represent generic objects better.  I.e. `Record<string, string>` maps to an object with string keys and string values.