### PR TITLE
fix: crashreporter is not an EventEmitter

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -132,12 +132,14 @@ const paramify = (paramName) => {
   }
   return paramName
 }
+// TODO: Infer through electron-docs-linter/parser
 const isEmitter = (module) => {
   switch (module.name.toLowerCase()) {
     case 'menu':
     case 'menuitem':
     case 'nativeimage':
     case 'shell':
+    case 'crashreporter':
       return false
     default:
       return true


### PR DESCRIPTION
The `crashReporter` API is not an EventEmitter